### PR TITLE
Turn off building of unneeded stuff.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,8 @@ stages:
           matrix:
             64-bit Linux Release:
               BuildType: Release
-            64-bit Linux RelWithDebInfo:
-              BuildType: RelWithDebInfo
+            64-bit Linux Debug:
+              BuildType: Debug
         steps:
           - checkout: self
             submodules: recursive
@@ -92,7 +92,8 @@ stages:
               BuildType: Release
             64-bit Windows RelWithDebInfo:
               BuildType: RelWithDebInfo
-
+            64-bit Windows Debug:
+              BuildType: Debug
         steps:
           - checkout: self
             submodules: recursive
@@ -139,6 +140,14 @@ stages:
               cd $(BUILD_DIRECTORY)
               cmake --build . --target install --config $(BuildType) -j 12
             displayName: BuildCommand
+          - script: |
+              cd $(INSTALL_DIRECTORY)/$(BuildType)
+              mv bin/llvm-config.exe .
+              rm -r bin
+              mkdir bin
+              mv llvm-config.exe bin
+              tree /f
+            displayName: RemoveExtraExecutables
           - task: CopyFiles@2
             inputs:
               contents: '$(INSTALL_DIRECTORY)/$(BuildType)/**'
@@ -161,11 +170,8 @@ stages:
           matrix:
             64-bit Mac Release:
               BuildType: Release
-              CMakeArgs: "-DCMAKE_INSTALL_PREFIX=../install-azure-release"
-            64-bit Mac RelWithDebInfo:
-              BuildType: RelWithDebInfo
-              CMakeArgs: "-DCMAKE_INSTALL_PREFIX=../install-azure-RelWithDebInfo"
-
+            64-bit Mac Debug:
+              BuildType: Debug
         steps:
           - checkout: self
             submodules: recursive
@@ -211,6 +217,14 @@ stages:
               cd $(BUILD_DIRECTORY)
               cmake --build . --target install --config $(BuildType) -j 12
             displayName: BuildCommand
+          - script: |
+              cd $(INSTALL_DIRECTORY)/$(BuildType)
+              mv bin/llvm-config* .
+              rm -r bin
+              mkdir bin
+              mv llvm-config* bin
+              tree /f
+            displayName: RemoveExtraExecutables
           - task: CopyFiles@2
             inputs:
               contents: '$(INSTALL_DIRECTORY)/$(BuildType)/**'

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -547,19 +547,19 @@ option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
 option(LLVM_BUILD_TOOLS
   "Build the LLVM tools. If OFF, just generate build targets." ON)
 
-option(LLVM_INCLUDE_UTILS "Generate build targets for the LLVM utils." ON)
+option(LLVM_INCLUDE_UTILS "Generate build targets for the LLVM utils." OFF)
 option(LLVM_BUILD_UTILS
-  "Build LLVM utility binaries. If OFF, just generate build targets." ON)
+  "Build LLVM utility binaries. If OFF, just generate build targets." OFF)
 
-option(LLVM_INCLUDE_RUNTIMES "Generate build targets for the LLVM runtimes." ON)
+option(LLVM_INCLUDE_RUNTIMES "Generate build targets for the LLVM runtimes." OFF)
 option(LLVM_BUILD_RUNTIMES
-  "Build the LLVM runtimes. If OFF, just generate build targets." ON)
+  "Build the LLVM runtimes. If OFF, just generate build targets." OFF)
 
 option(LLVM_BUILD_RUNTIME
   "Build the LLVM runtime libraries." ON)
 option(LLVM_BUILD_EXAMPLES
   "Build the LLVM example programs. If OFF, just generate build targets." OFF)
-option(LLVM_INCLUDE_EXAMPLES "Generate build targets for the LLVM examples" ON)
+option(LLVM_INCLUDE_EXAMPLES "Generate build targets for the LLVM examples" OFF)
 
 if(LLVM_BUILD_EXAMPLES)
   add_definitions(-DBUILD_EXAMPLES)
@@ -567,18 +567,18 @@ endif(LLVM_BUILD_EXAMPLES)
 
 option(LLVM_BUILD_TESTS
   "Build LLVM unit tests. If OFF, just generate build targets." OFF)
-option(LLVM_INCLUDE_TESTS "Generate build targets for the LLVM unit tests." ON)
-option(LLVM_INCLUDE_GO_TESTS "Include the Go bindings tests in test build targets." ON)
+option(LLVM_INCLUDE_TESTS "Generate build targets for the LLVM unit tests." OFF)
+option(LLVM_INCLUDE_GO_TESTS "Include the Go bindings tests in test build targets." OFF)
 
 option(LLVM_BUILD_BENCHMARKS "Add LLVM benchmark targets to the list of default
 targets. If OFF, benchmarks still could be built using Benchmarks target." OFF)
-option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks can't be built." ON)
+option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks can't be built." OFF)
 
 option (LLVM_BUILD_DOCS "Build the llvm documentation." OFF)
-option (LLVM_INCLUDE_DOCS "Generate build targets for llvm documentation." ON)
+option (LLVM_INCLUDE_DOCS "Generate build targets for llvm documentation." OFF)
 option (LLVM_ENABLE_DOXYGEN "Use doxygen to generate llvm API documentation." OFF)
 option (LLVM_ENABLE_SPHINX "Use Sphinx to generate llvm documentation." OFF)
-option (LLVM_ENABLE_OCAMLDOC "Build OCaml bindings documentation." ON)
+option (LLVM_ENABLE_OCAMLDOC "Build OCaml bindings documentation." OFF)
 option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 
 set(LLVM_INSTALL_DOXYGEN_HTML_DIR "share/doc/llvm/doxygen-html"

--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -24,27 +24,27 @@ endif()
 # Add LTO, llvm-ar, llvm-config, and llvm-profdata before clang, ExternalProject
 # requires targets specified in DEPENDS to exist before the call to
 # ExternalProject_Add.
-add_llvm_tool_subdirectory(lto)
-add_llvm_tool_subdirectory(gold)
-add_llvm_tool_subdirectory(llvm-ar)
+#add_llvm_tool_subdirectory(lto)
+#add_llvm_tool_subdirectory(gold)
+#add_llvm_tool_subdirectory(llvm-ar)
 add_llvm_tool_subdirectory(llvm-config)
-add_llvm_tool_subdirectory(llvm-lto)
-add_llvm_tool_subdirectory(llvm-profdata)
+#add_llvm_tool_subdirectory(llvm-lto)
+#add_llvm_tool_subdirectory(llvm-profdata)
 
 # Projects supported via LLVM_EXTERNAL_*_SOURCE_DIR need to be explicitly
 # specified.
-add_llvm_external_project(clang)
-add_llvm_external_project(lld)
-add_llvm_external_project(lldb)
-add_llvm_external_project(mlir)
+#add_llvm_external_project(clang)
+#add_llvm_external_project(lld)
+#add_llvm_external_project(lldb)
+#add_llvm_external_project(mlir)
 # Flang depends on mlir, so place it afterward
-add_llvm_external_project(flang)
+#add_llvm_external_project(flang)
 
 # Automatically add remaining sub-directories containing a 'CMakeLists.txt'
 # file as external projects.
-add_llvm_implicit_projects()
+#add_llvm_implicit_projects()
 
-add_llvm_external_project(polly)
+#add_llvm_external_project(polly)
 
 # Add subprojects specified using LLVM_EXTERNAL_PROJECTS
 foreach(p ${LLVM_EXTERNAL_PROJECTS})


### PR DESCRIPTION
This reduces the Windows debug distribution from ~7GB to ~4GB.